### PR TITLE
Fix new Chrome cookie policy. Validate that SameSite=None also has

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -790,6 +790,22 @@ function formCookieData(form) {
             $(".expiration", form).removeClass("error");
         }
     }
+
+    /*
+     * New Chrome restrictions do not allow SameSite=None without Secure being
+     * marked as true.
+     */
+    if (sameSite === 'no_restriction' && !secure) {
+      $(".sameSite", form).addClass("error");
+      $(".sameSite", form).focus();
+      $(".error-message").html("'No Restriction' requires that Secure be checked.");
+      $(".error-message").show();
+      return undefined;
+    } else {
+      $(".sameSite", form).removeClass("error");
+      $(".error-message").hide();
+    }
+
     newCookie.secure = secure;
     newCookie.httpOnly = httpOnly;
     newCookie.sameSite = sameSite;

--- a/popup.html
+++ b/popup.html
@@ -227,7 +227,7 @@
                     <label class="formLabel" i18n="sameSite"></label>
                     <select class="sameSite input" type="text">
                         <option selected="selected" i18n="SameSite_None" value="no_restriction"></option>
-                        <option i18n="SameSite_Lax" value="lax"></option>
+                        <option i18n="SameSite_Lax" value="lax" selected></option>
                         <option i18n="SameSite_Strict" value="strict"></option>
                     </select>
                 </div>
@@ -249,6 +249,7 @@
                         <input id="httpOnly-checkbox-new" class="httpOnly checkbox" type="checkbox">
                     </div>
                 </div>
+              <div class="error-message error" style="display: none"></div>
             </div>
         </div>
 


### PR DESCRIPTION
Secure checked. Change default SameSite to Lax to handle the simplest
case of setting a cookie. #276