### PR TITLE
Fix new Chrome cookie policy. Validate that SameSite=None also hasSecure checked. Change default SameSite to Lax to handle the simplestcase of setting a cookie. #276

### DIFF
--- a/js/cookie_helpers.js
+++ b/js/cookie_helpers.js
@@ -60,7 +60,8 @@ function Filter() {
 function cookieForCreationFromFullCookie(fullCookie) {
     var newCookie = {};
     //If no real url is available use: "https://" : "http://" + domain + path
-    newCookie.url = "http" + ((fullCookie.secure) ? "s" : "") + "://" + fullCookie.domain + fullCookie.path;
+    var domain = fullCookie.domain.replace(/^\./, '');
+    newCookie.url = "http" + ((fullCookie.secure) ? "s" : "") + "://" + domain + fullCookie.path;
     newCookie.name = fullCookie.name;
     newCookie.value = fullCookie.value;
     if (!fullCookie.hostOnly)


### PR DESCRIPTION
Fixes error "Unchecked runtime.lastError: Failed to parse or set cookie named"